### PR TITLE
upgrade isort to 5.0.0+

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,14 +26,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 yapf isort==4.3.21
+        pip install flake8 yapf isort
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint
       run: |
         echo "Runing flake8"
         flake8 foundation/ tests/
         echo "Runing isort"
-        isort -rc --check-only --diff foundation/ tests/
+        isort --check-only --diff foundation/ tests/
         echo "Runing yapf"
         yapf -r -d foundation/ tests/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,8 @@ repos:
         '--select=B,C,E,F,W,T4,B9',
         '--exclude=build,__init__.py'
       ]
-- repo: https://github.com/asottile/seed-isort-config
-  rev: v2.1.0
-  hooks:
-    - id: seed-isort-config
 - repo: https://github.com/timothycrosley/isort
-  rev: 4.3.21
+  rev: 5.2.1
   hooks:
     - id: isort
 - repo: https://github.com/pre-commit/mirrors-yapf

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,13 +8,11 @@ addopts = tests/
 line_length = 100
 multi_line_output = 3
 include_trailing_comma = True
-# TODO: upgrade isort to 5.* when seed_isort_config is compatible
-known_standard_library = pkg_resources,setuptools
+extra_standard_library = pkg_resources,setuptools
 known_first_party = foundation
 default_section = THIRDPARTY
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 no_lines_before = LOCALFOLDER
-known_third_party = cv2,matplotlib,numpy,portalocker,pycocotools,six,torch,yacs,yaml
 combine_as_imports = True
 force_grid_wrap = 0
 force_single_line = False


### PR DESCRIPTION
1. remove seed-isort-config since it is unnecessary for isort 5.0+: https://github.com/asottile/seed-isort-config/issues/72

2. change `know_standard_library` to `extra_standard_library`; remove `known_third_library`: https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/#known_standard_library

Signed-off-by: Zhipeng Han <hanzhipeng9@gmail.com>