### PR TITLE
remove known_first_party option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ line_length = 100
 multi_line_output = 3
 include_trailing_comma = True
 extra_standard_library = pkg_resources,setuptools
-known_first_party = foundation
 default_section = THIRDPARTY
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 no_lines_before = LOCALFOLDER


### PR DESCRIPTION
According to https://github.com/timothycrosley/isort/issues/1147, import code exists in same directory as any files isort is told to sort will be recognized as FIRSTPARTY

Signed-off-by: Zhipeng Han <hanzhipeng9@gmail.com>